### PR TITLE
update array_where usage

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -4,10 +4,10 @@ if (!function_exists('sortArrayKeysToOrder')){
     function sortArrayKeysToOrder($array, $keysOrder){
         if (!is_array($array)) return $array;
         $keysOrder = array_flip($keysOrder);
-        $nonExistingItems = array_where($array, function($key, $value) use ($keysOrder){
+        $nonExistingItems = array_where($array, function($value, $key) use ($keysOrder){
             return !isset($keysOrder[$key]);
         });
-        $existingItems = array_where($array, function($key, $value) use ($keysOrder){
+        $existingItems = array_where($array, function($value, $key) use ($keysOrder){
             return isset($keysOrder[$key]);
         });
 


### PR DESCRIPTION
Since Laravel 5.3 the array_where should be used like this:

$array = array_where($array, function ($value, $key) {
    return is_string($value);
});

https://laravel.com/docs/5.3/helpers#method-array-where